### PR TITLE
Change documentation strategy for the base repository

### DIFF
--- a/src/BaseRepository.php
+++ b/src/BaseRepository.php
@@ -590,6 +590,9 @@ abstract class BaseRepository implements BaseRepositoryInterface
      * (misc): Returns default per page count.
      *
      * @return int
+     *
+     * @throws RepositoryException
+     * @throws BindingResolutionException
      */
     protected function getDefaultPerPage(): int
     {

--- a/src/BaseRepository.php
+++ b/src/BaseRepository.php
@@ -18,7 +18,6 @@ use Illuminate\Database\Query\Builder as DatabaseBuilder;
 use Illuminate\Support\Collection;
 use Illuminate\Container\Container as App;
 use InvalidArgumentException;
-use JetBrains\PhpStorm\Pure;
 
 /**
  * Basic repository for retrieving and manipulating Eloquent models.
@@ -336,7 +335,8 @@ abstract class BaseRepository implements BaseRepositoryInterface
     /**
      * Check if the returned custom callback is valid.
      *
-     * @throws InvalidArgumentException
+     * @param  string|EloquentBuilder|DatabaseBuilder|Model $result
+     * @return void
      */
     protected function checkValidCustomCallback(string|EloquentBuilder|DatabaseBuilder|Model $result): void
     {
@@ -426,12 +426,9 @@ abstract class BaseRepository implements BaseRepositoryInterface
 
         // overrule them with criteria to be applied once
         if ( ! $this->onceCriteria->isEmpty()) {
-
             foreach ($this->onceCriteria as $onceKey => $onceCriteria) {
-
                 // if there is no key, we can only add the criteria
                 if (is_numeric($onceKey)) {
-
                     $criteriaToApply->push($onceCriteria);
                     continue;
                 }
@@ -561,11 +558,7 @@ abstract class BaseRepository implements BaseRepositoryInterface
         return $this;
     }
 
-    /**
-     * Pushes Criteria, but only for the next call, resets to default afterwards
-     * Note that this does NOT work for specific criteria exclusively, it resets
-     * to default for ALL Criteria.
-     */
+    /** {@inheritdoc} */
     public function pushCriteriaOnce(CriteriaInterface $criteria, ?string $key = null): self
     {
         if (is_null($key)) {

--- a/src/BaseRepository.php
+++ b/src/BaseRepository.php
@@ -32,8 +32,6 @@ use InvalidArgumentException;
  */
 abstract class BaseRepository implements BaseRepositoryInterface
 {
-    protected App $app;
-
     protected Model|EloquentBuilder $model;
 
     /**
@@ -43,10 +41,8 @@ abstract class BaseRepository implements BaseRepositoryInterface
 
     /**
      * The Criteria to only apply to the next query
-     *
-     * @var Collection|CriteriaInterface[]
      */
-    protected Collection $onceCriteria;
+    protected Collection|CriteriaInterface|array $onceCriteria;
 
     /**
      * List of criteria that are currently active (updates when criteria are stripped)
@@ -67,15 +63,21 @@ abstract class BaseRepository implements BaseRepositoryInterface
 
 
     /**
+     * BaseRepository Constructor
+     *
+     * @param  App        $app
+     * @param  Collection $collection
+     * @return void
+     *
+     * @throws BindingResolutionException
      * @throws RepositoryException
      */
-    public function __construct(App $app, Collection $collection)
+    public function __construct(protected App $app, Collection $collection)
     {
         if ($collection->isEmpty()) {
             $collection = $this->defaultCriteria();
         }
 
-        $this->app            = $app;
         $this->criteria       = $collection;
         $this->onceCriteria   = new Collection();
         $this->activeCriteria = new Collection();
@@ -84,19 +86,10 @@ abstract class BaseRepository implements BaseRepositoryInterface
     }
 
 
-    /**
-     * Returns specified model class name.
-     */
+    /** {@inheritdoc} */
     public abstract function model(): string;
 
-
-    /**
-     * Creates instance of model to start building query for
-     *
-     * @param  bool $storeModel  if true, this becomes a fresh $this->model property
-     *
-     * @throws RepositoryException|BindingResolutionException
-     */
+    /** {@inheritdoc} */
     public function makeModel(bool $storeModel = true): EloquentBuilder|Model
     {
         $model = $this->app->make($this->model());
@@ -117,11 +110,7 @@ abstract class BaseRepository implements BaseRepositoryInterface
     //      Retrieval methods
     // -------------------------------------------------------------------------
 
-    /**
-     * Give un executed query for current criteria
-     *
-     * @throws RepositoryException
-     */
+    /** {@inheritdoc} */
     public function query(): EloquentBuilder
     {
         $this->applyCriteria();
@@ -133,27 +122,19 @@ abstract class BaseRepository implements BaseRepositoryInterface
         return clone $this->model;
     }
 
-    /**
-     * Does a simple count(*) for the model / scope
-     */
+    /** {@inheritdoc} */
     public function count(): int
     {
         return $this->query()->count();
     }
 
-    /**
-     * Returns first match
-     */
+    /** {@inheritdoc} */
     public function first(array|null|string $columns = ['*']): ?Model
     {
         return $this->query()->first($columns);
     }
 
-    /**
-     * Returns first match or throws exception if not found
-     *
-     * @throws ModelNotFoundException
-     */
+    /** {@inheritdoc} */
     public function firstOrFail(array $columns = ['*']): Model
     {
         $result = $this->query()->first($columns);
@@ -165,19 +146,13 @@ abstract class BaseRepository implements BaseRepositoryInterface
         throw (new ModelNotFoundException())->setModel($this->model());
     }
 
-    /**
-     * {@inheritdoc}
-     */
+    /** {@inheritdoc} */
     public function all(array|string $columns = ['*']): DatabaseCollection
     {
         return $this->query()->get($columns);
     }
 
-    /**
-     * {@inheritdoc}
-     *
-     * @throws RepositoryException
-     */
+    /** {@inheritdoc} */
     public function pluck(string $value, ?string $key = null): array
     {
         $this->applyCriteria();
@@ -191,19 +166,13 @@ abstract class BaseRepository implements BaseRepositoryInterface
         return $lists->all();
     }
 
-    /**
-     * {@inheritdoc}
-     *
-     * @throws RepositoryException
-     */
+    /** {@inheritdoc} */
     public function lists(string $value, ?string $key = null): array
     {
         return $this->pluck($value, $key);
     }
 
-    /**
-     * {@inheritdoc}
-     */
+    /** {@inheritdoc} */
     public function paginate(int $perPage = null, array $columns = ['*'], string $pageName = 'page', ?int $page = null): LengthAwarePaginator
     {
         $perPage = $perPage ?: $this->getDefaultPerPage();
@@ -211,9 +180,7 @@ abstract class BaseRepository implements BaseRepositoryInterface
         return $this->query()->paginate($perPage, $columns, $pageName, $page);
     }
 
-    /**
-     * {@inheritdoc}
-     */
+    /** {@inheritdoc} */
     public function find(mixed $id, array $columns = ['*'], ?string $attribute = null): ?Model
     {
         $query = $this->query();
@@ -225,11 +192,7 @@ abstract class BaseRepository implements BaseRepositoryInterface
         return $query->find($id, $columns);
     }
 
-    /**
-     * Returns first match or throws exception if not found
-     *
-     * @throws ModelNotFoundException
-     */
+    /** {@inheritdoc} */
     public function findOrFail(int|string $id, array $columns = ['*']): Model
     {
         $result = $this->query()->find($id, $columns);
@@ -241,25 +204,19 @@ abstract class BaseRepository implements BaseRepositoryInterface
         throw (new ModelNotFoundException())->setModel($this->model(), $id);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function findBy(string $attribute, mixed $value, array $columns = ['*']): mixed
+    /** {@inheritdoc} */
+    public function findBy(string $attribute, mixed $value, array $columns = ['*']): EloquentBuilder|Model|null
     {
         return $this->query()->where($attribute, $value)->first($columns);
     }
 
-    /**
-     * {@inheritdoc}
-     */
+    /** {@inheritdoc} */
     public function findAllBy(string $attribute, mixed $value, array $columns = ['*']): mixed
     {
         return $this->query()->where($attribute, $value)->get($columns);
     }
 
-    /**
-     * Find a collection of models by the given query conditions.
-     */
+    /** {@inheritdoc} */
     public function findWhere(array|Arrayable $where, array $columns = ['*'], bool $or = false): ?Collection
     {
         $model = $this->query();
@@ -327,12 +284,7 @@ abstract class BaseRepository implements BaseRepositoryInterface
         return $this->makeModel(false)->create($data);
     }
 
-    /**
-     * Updates a model by id
-     *
-     * Returns false when the model couldn't updated or is not found
-     * in the database storage.
-     */
+    /** {@inheritdoc} */
     public function update(array $data, mixed $id, ?string $attribute = null): bool
     {
         $model = $this->find($id, ['*'], $attribute);
@@ -344,11 +296,7 @@ abstract class BaseRepository implements BaseRepositoryInterface
         return $model->fill($data)->save();
     }
 
-    /**
-     * Finds and fills a model by id, without persisting changes
-     *
-     * @throws \Illuminate\Database\Eloquent\MassAssignmentException
-     */
+    /** {@inheritdoc} */
     public function fill(array $data, mixed $id, ?string $attribute = null): Model|bool
     {
         $model = $this->find($id, ['*'], $attribute);
@@ -360,11 +308,7 @@ abstract class BaseRepository implements BaseRepositoryInterface
         return $model->fill($data);
     }
 
-    /**
-     * Deletes a model by id
-     *
-     * @throws RepositoryException
-     */
+    /** {@inheritdoc} */
     public function delete(mixed $id): bool
     {
         return $this->makeModel(false)->destroy($id);
@@ -418,10 +362,7 @@ abstract class BaseRepository implements BaseRepositoryInterface
      */
     protected function checkValidCustomCallback(string|EloquentBuilder|DatabaseBuilder|Model $result): void
     {
-        if (    ! is_a($result, Model::class)
-            &&  ! is_a($result, EloquentBuilder::class)
-            &&  ! is_a($result, DatabaseBuilder::class)
-        ) {
+        if (! is_a($result, Model::class) && ! is_a($result, EloquentBuilder::class) && ! is_a($result, DatabaseBuilder::class)) {
             throw new InvalidArgumentException('Incorrect allCustom call in repository. The callback must return a QueryBuilder/EloquentBuilder or Model object.');
         }
     }
@@ -448,11 +389,7 @@ abstract class BaseRepository implements BaseRepositoryInterface
         return new Collection();
     }
 
-
-    /**
-     * Builds the default criteria and replaces the criteria stack to apply with
-     * the default collection.
-     */
+    /** {@inheritdoc} */
     public function restoreDefaultCriteria(): self
     {
         $this->criteria = $this->defaultCriteria();
@@ -460,10 +397,7 @@ abstract class BaseRepository implements BaseRepositoryInterface
         return $this;
     }
 
-
-    /**
-     * Sets criteria to empty collection
-     */
+    /** {@inheritdoc} */
     public function clearCriteria(): self
     {
         $this->criteria = new Collection();
@@ -471,10 +405,6 @@ abstract class BaseRepository implements BaseRepositoryInterface
         return $this;
     }
 
-    /**
-     * Sets or unsets ignoreCriteria flag. If it is set, all criteria (even
-     * those set to apply once!) will be ignored.
-     */
     public function ignoreCriteria(bool $ignore = true): self
     {
         $this->ignoreCriteria = $ignore;
@@ -551,6 +481,7 @@ abstract class BaseRepository implements BaseRepositoryInterface
      * them with whatever is found in the onceCriteria list
      *
      * @throws RepositoryException
+     * @throws BindingResolutionException
      */
     public function applyCriteria(): self
     {
@@ -590,6 +521,8 @@ abstract class BaseRepository implements BaseRepositoryInterface
     /**
      * Checks whether the criteria that are currently pushed
      * are the same as the ones that were previously applied
+     *
+     * @return bool
      */
     protected function areActiveCriteriaUnchanged(): bool
     {
@@ -599,6 +532,8 @@ abstract class BaseRepository implements BaseRepositoryInterface
     /**
      * Marks the active criteria so we can later check what
      * is currently active
+     *
+     * @return void
      */
     protected function markAppliedCriteriaAsActive(): void
     {
@@ -672,14 +607,7 @@ abstract class BaseRepository implements BaseRepositoryInterface
     }
 
 
-    /**
-     * Removes Criteria, but only for the next call, resets to default afterwards
-     * Note that this does NOT work for specific criteria exclusively, it resets
-     * to default for ALL Criteria.
-     *
-     * In effect, this adds a NullCriteria to onceCriteria by key, disabling any criteria
-     * by that key in the normal criteria list.
-     */
+    /** {@inheritdoc} */
     public function removeCriteriaOnce(string $key): self
     {
         // if not present in normal list, there is nothing to override
@@ -693,6 +621,8 @@ abstract class BaseRepository implements BaseRepositoryInterface
 
     /**
      * (misc): Returns default per page count.
+     *
+     * @return int
      */
     protected function getDefaultPerPage(): int
     {

--- a/src/BaseRepository.php
+++ b/src/BaseRepository.php
@@ -18,6 +18,7 @@ use Illuminate\Database\Query\Builder as DatabaseBuilder;
 use Illuminate\Support\Collection;
 use Illuminate\Container\Container as App;
 use InvalidArgumentException;
+use JetBrains\PhpStorm\Pure;
 
 /**
  * Basic repository for retrieving and manipulating Eloquent models.
@@ -263,22 +264,13 @@ abstract class BaseRepository implements BaseRepositoryInterface
     //      Manipulation methods
     // -------------------------------------------------------------------------
 
-    /**
-     * Makes a new model without persisting it
-     *
-     * @throws \Illuminate\Database\Eloquent\MassAssignmentException
-     * @throws RepositoryException
-     */
+    /** {@inheritdoc} */
     public function make(array $data): Model
     {
         return $this->makeModel(false)->fill($data);
     }
 
-    /**
-     * Creates a model and returns it
-     *
-     * @throws RepositoryException
-     */
+    /** {@inheritdoc} */
     public function create(array $data): ?Model
     {
         return $this->makeModel(false)->create($data);
@@ -319,14 +311,7 @@ abstract class BaseRepository implements BaseRepositoryInterface
     //      With custom callback
     // -------------------------------------------------------------------------
 
-    /**
-     * Applies callback to query for easier elaborate custom queries
-     * on all() calls.
-     *
-     * The callback mist be compatible with an query/builder entity
-     *
-     * @throws \Exception
-     */
+    /** {@inheritdoc} */
     public function allCallback(Closure $callback, array $columns = ['*']): Collection
     {
         /** @var EloquentBuilder $result */
@@ -337,14 +322,7 @@ abstract class BaseRepository implements BaseRepositoryInterface
         return $result->get($columns);
     }
 
-    /**
-     * Applies callback to query for easier elaborate custom queries
-     * on find (actually: ->first()) calls.
-     *
-     * The callback mist be compatible with an query/builder entity
-     *
-     * @throws \Exception
-     */
+    /** {@inheritdoc} */
     public function findCallback(Closure $callback, array $columns = ['*']): Collection|Model
     {
         /** @var EloquentBuilder $result */
@@ -493,6 +471,7 @@ abstract class BaseRepository implements BaseRepositoryInterface
                 $this->makeModel();
                 $this->activeCriteria = new Collection();
             }
+
             return $this;
         }
 
@@ -500,15 +479,12 @@ abstract class BaseRepository implements BaseRepositoryInterface
 
         // if the new Criteria are different, clear the model and apply the new Criteria
         $this->makeModel();
-
         $this->markAppliedCriteriaAsActive();
 
 
         // apply the collected criteria to the query
         foreach ($this->getCriteriaToApply() as $criteria) {
-
             if ($criteria instanceof CriteriaInterface) {
-
                 $this->model = $criteria->apply($this->model, $this);
             }
         }
@@ -577,9 +553,7 @@ abstract class BaseRepository implements BaseRepositoryInterface
         return $this;
     }
 
-    /**
-     * Removes criteria by key, if it exists
-     */
+    /** {@inheritdoc} */
     public function removeCriteria(string $key): self
     {
         $this->criteria->forget($key);

--- a/src/Contracts/BaseRepositoryInterface.php
+++ b/src/Contracts/BaseRepositoryInterface.php
@@ -162,7 +162,7 @@ interface BaseRepositoryInterface
      * @param  string $attribute
      * @param  mixed  $value
      * @param  array  $columns
-     * @return mixed
+     * @return EloquentBuilder|Model|null
      *
      * @throws RepositoryException
      * @throws BindingResolutionException
@@ -228,6 +228,9 @@ interface BaseRepositoryInterface
      * @param  mixed       $id
      * @param  string|null $attribute
      * @return bool
+     *
+     * @throws RepositoryException
+     * @throws BindingResolutionException
      */
     public function update(array $data, mixed $id, ?string $attribute = null): bool;
 

--- a/src/Contracts/BaseRepositoryInterface.php
+++ b/src/Contracts/BaseRepositoryInterface.php
@@ -70,7 +70,7 @@ interface BaseRepositoryInterface
     /**
      * Returns first match or throws exception if not found
      *
-     * @param  array $columns
+     * @param  array $columns   The columns that u wish to use from the collection.
      * @return Model
      *
      * @throws ModelNotFoundException
@@ -82,7 +82,7 @@ interface BaseRepositoryInterface
     /**
      * Method for getting all the results in the database table.
      *
-     * @param  array $columns
+     * @param  array $columns   The columns that u wish to use from the collection.
      * @return EloquentCollection
      *
      * @throws RepositoryException
@@ -93,8 +93,8 @@ interface BaseRepositoryInterface
     /**
      * Get an array with the values of a given key.
      *
-     * @param  string      $value
-     * @param  string|null $key
+     * @param  string      $value   The value for the array
+     * @param  string|null $key     The key for the array
      * @return array
      *
      * @throws RepositoryException
@@ -107,8 +107,8 @@ interface BaseRepositoryInterface
      *
      * @deprecated
      *
-     * @param  string      $value
-     * @param  string|null $key
+     * @param  string      $value   The value for the array
+     * @param  string|null $key     The key for the array
      * @return array
      *
      * @throws BindingResolutionException
@@ -119,10 +119,10 @@ interface BaseRepositoryInterface
     /**
      * Paginate the given query.
      *
-     * @param  int      $perPage
-     * @param  array    $columns
-     * @param  string   $pageName
-     * @param  int|null $page
+     * @param  int      $perPage    The amount of records per page.
+     * @param  array    $columns    The columns u wish to use from the collection.
+     * @param  string   $pageName   The name for the page parameter in the url
+     * @param  int|null $page       The indicator for tha page where the user is at.
      * @return LengthAwarePaginator
      *
      * @throws RepositoryException
@@ -133,9 +133,9 @@ interface BaseRepositoryInterface
     /**
      * Find a model in the collection by key.
      *
-     * @param  int|string  $id
-     * @param  array       $columns
-     * @param  string|null $attribute
+     * @param  int|string  $id          The identifier for the database record. It will be used in an WHERE clause
+     * @param  array       $columns     The columns that u wish to use from the collection.
+     * @param  string|null $attribute   The database table column that will be used in the WHERE clause
      * @return Model|null
      *
      * @throws RepositoryException
@@ -146,8 +146,8 @@ interface BaseRepositoryInterface
     /**
      * Returns first match or throws exception if not found
      *
-     * @param  int|string $id
-     * @param  array      $columns
+     * @param  int|string $id       The unique identifier from the database record.
+     * @param  array      $columns  The database columns that u wish to use from the collection
      * @return Model
      *
      * @throws ModelNotFoundException
@@ -159,9 +159,9 @@ interface BaseRepositoryInterface
     /**
      * Find record by the attribute and value combination.
      *
-     * @param  string $attribute
-     * @param  mixed  $value
-     * @param  array  $columns
+     * @param  string $attribute    The database table his column name for the WHERE clause
+     * @param  mixed  $value        The value for the where clause
+     * @param  array  $columns      The database columns that u wish to use from the collection.
      * @return EloquentBuilder|Model|null
      *
      * @throws RepositoryException
@@ -172,9 +172,9 @@ interface BaseRepositoryInterface
     /**
      * Find all collection items matched by the attribute and value pair.
      *
-     * @param  string $attribute
-     * @param  mixed  $value
-     * @param  array  $columns
+     * @param  string $attribute    The database table his column name for the WHERE clause
+     * @param  mixed  $value        The value for the where clause
+     * @param  array  $columns      The database columns that u wish to use from the collection.
      * @return mixed
      *
      * @throws RepositoryException
@@ -185,9 +185,9 @@ interface BaseRepositoryInterface
     /**
      * Find a collection of models by the given query conditions.
      *
-     * @param  array $where
-     * @param  array $columns
-     * @param  bool  $or
+     * @param  array $where     The data array for the where clauses.
+     * @param  array $columns   The database columns that u wish to use from the query result.
+     * @param  bool  $or        Configuration flag for determining is OR WHERE clauses will be used or not.
      * @return Collection|null
      *
      * @throws RepositoryException
@@ -198,7 +198,7 @@ interface BaseRepositoryInterface
     /**
      * Makes a new model without persisting it
      *
-     * @param  array $data
+     * @param  array $data  The data for the database record that u want to create.
      * @return Model
      *
      * @throws MassAssignmentException
@@ -210,7 +210,7 @@ interface BaseRepositoryInterface
     /**
      * Creates a model and returns it
      *
-     * @param  array $data
+     * @param  array $data  The data that u want to store in the database table.
      * @return Model|null
      *
      * @throws BindingResolutionException
@@ -224,9 +224,9 @@ interface BaseRepositoryInterface
      * Returns false when the model couldn't updated or is not found
      * in the database storage.
      *
-     * @param  array       $data
-     * @param  mixed       $id
-     * @param  string|null $attribute
+     * @param  array       $data      The new data for the database record.
+     * @param  mixed       $id        The identifier for the where clause
+     * @param  string|null $attribute The database column name for the where clause.
      * @return bool
      *
      * @throws RepositoryException
@@ -237,9 +237,9 @@ interface BaseRepositoryInterface
     /**
      * Finds and fills a model by id, without persisting changes?
      *
-     * @param  array       $data
-     * @param  mixed       $id
-     * @param  string|null $attribute
+     * @param  array       $data      The data which will be used to fill the database record.
+     * @param  mixed       $id        The identifier for the where clause.
+     * @param  string|null $attribute The database column name for the where cause
      * @return Model|bool|null
      *
      * @throws RepositoryException
@@ -250,7 +250,7 @@ interface BaseRepositoryInterface
     /**
      * Deletes a model by $id
      *
-     * @param  string|int $id
+     * @param  string|int $id The unique identifier from the resource that u want to delete.
      * @return bool
      *
      * @throws BindingResolutionException
@@ -264,8 +264,8 @@ interface BaseRepositoryInterface
      *
      * The callback must be query/builder compatible.
      *
-     * @param  Closure $callback
-     * @param  array   $columns
+     * @param  Closure $callback    The closure that acts as an callback in the repository.
+     * @param  array   $columns     The columns u want to use from the database table.
      * @return Collection
      *
      * @throws Exception
@@ -278,8 +278,8 @@ interface BaseRepositoryInterface
      *
      * The callback must be query/builder compatible.
      *
-     * @param  Closure $callback
-     * @param  array   $columns
+     * @param  Closure $callback    The closure that acts as an callback in the repository.
+     * @param  array   $columns     The columns u want to use from the database table.
      * @return Collection|Model
      *
      * @throws Exception
@@ -317,7 +317,7 @@ interface BaseRepositoryInterface
      * Sets or unsets ignoreCriteria flag. If it is set, all criteria (even
      * those set to apply once!) will be ignored.
      *
-     * @param  bool $ignore =
+     * @param  bool $ignore The status flag for configuring if u want to ignore the criteria.
      * @return self
      */
     public function ignoreCriteria(bool $ignore = true): self;
@@ -346,7 +346,7 @@ interface BaseRepositoryInterface
      *
      * Note that this does NOT overrule any onceCriteria, even if set by key!
      *
-     * @param CriteriaInterface $criteria
+     * @param CriteriaInterface $criteria     The criteria interface that u want to push once.
      * @param string|null       $key          unique identifier to store criteria as
      *                                        this may be used to remove and overwrite criteria
      *                                        empty for normal automatic numeric key
@@ -357,7 +357,7 @@ interface BaseRepositoryInterface
     /**
      * Removes criteria by key, if it exists
      *
-     * @param  string $key
+     * @param  string $key The unique key of the criteria that you want to remove.
      * @return self
      */
     public function removeCriteria(string $key): self;
@@ -367,8 +367,8 @@ interface BaseRepositoryInterface
      * Note that this does NOT work for specific criteria exclusively, it resets
      * to default for ALL Criteria.
      *
-     * @param  CriteriaInterface    $criteria
-     * @param  string|null          $key
+     * @param  CriteriaInterface    $criteria The criteria interface that u want to push only once.
+     * @param  string|null          $key      The unique key of the criteria.
      * @return self
      */
     public function pushCriteriaOnce(CriteriaInterface $criteria, ?string $key = null): self;
@@ -381,7 +381,7 @@ interface BaseRepositoryInterface
      * In effect, this adds a NullCriteria to onceCriteria by key, disabling any criteria
      * by that key in the normal criteria list.
      *
-     * @param  string $key
+     * @param  string $key The unique key of the criteria that u want to remove once.
      * @return self
      */
     public function removeCriteriaOnce(string $key): self;

--- a/src/Contracts/BaseRepositoryInterface.php
+++ b/src/Contracts/BaseRepositoryInterface.php
@@ -9,6 +9,7 @@ use Illuminate\Contracts\Container\BindingResolutionException;
 use Illuminate\Contracts\Pagination\LengthAwarePaginator;
 use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
 use Illuminate\Database\Eloquent\Collection as EloquentCollection;
+use Illuminate\Database\Eloquent\MassAssignmentException;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Support\Collection;
@@ -199,6 +200,10 @@ interface BaseRepositoryInterface
      *
      * @param  array $data
      * @return Model
+     *
+     * @throws MassAssignmentException
+     * @throws RepositoryException
+     * @throws BindingResolutionException
      */
     public function make(array $data): Model;
 
@@ -207,6 +212,9 @@ interface BaseRepositoryInterface
      *
      * @param  array $data
      * @return Model|null
+     *
+     * @throws BindingResolutionException
+     * @throws RepositoryException
      */
     public function create(array $data): ?Model;
 

--- a/src/Contracts/BaseRepositoryInterface.php
+++ b/src/Contracts/BaseRepositoryInterface.php
@@ -4,8 +4,8 @@ namespace Czim\Repository\Contracts;
 
 use Closure;
 use Czim\Repository\Exceptions\RepositoryException;
+use Exception;
 use Illuminate\Contracts\Pagination\LengthAwarePaginator;
-use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
 use Illuminate\Database\Eloquent\Collection as EloquentCollection;
 use Illuminate\Database\Eloquent\Model;
@@ -18,6 +18,8 @@ interface BaseRepositoryInterface
      * Returns specified model class name.
      *
      * Note that this is the only abstract method.
+     *
+     * @return string
      */
     public function model(): string;
 
@@ -25,29 +27,39 @@ interface BaseRepositoryInterface
      * Creates instance of model to start building query for
      *
      * @param  bool $storeModel if true, this becomes a fresh $this->model property
-     * @return EloquentBuilder
+     * @return EloquentBuilder|Model
      *
      * @throws RepositoryException
      */
-    public function makeModel(bool $storeModel = true): EloquentBuilder|Model;
+    public function makeModel(bool $storeModel = true): EloquentBuilder | Model;
 
     /**
      * Give un executed query for current criteria
+     *
+     * @return EloquentBuilder
      */
     public function query(): EloquentBuilder;
 
     /**
-     * Does a simple count(*) for the model / scope
+     * Does a simple count(*) for the model/scope
+     *
+     * @return int
      */
     public function count(): int;
 
     /**
      * Returns first match
+     *
+     * @param  array $columns The colums u want to select from your query output
+     * @return Model|null
      */
-    public function first(?array $columns = ['*']): ?Model;
+    public function first(array $columns = ['*']): ?Model;
 
     /**
      * Returns first match or throws exception if not found
+     *
+     * @param  array $columns
+     * @return Model
      *
      * @throws ModelNotFoundException
      */
@@ -55,33 +67,59 @@ interface BaseRepositoryInterface
 
     /**
      * Method for getting all the results in the database table.
+     *
+     * @param  array $columns
+     * @return EloquentCollection
      */
     public function all(array $columns = ['*']): EloquentCollection;
 
     /**
      * Get an array with the values of a given key.
+     *
+     * @param  string      $value
+     * @param  string|null $key
+     * @return array
      */
-    public function pluck(string $value, ?string $key = null): array;
+    public function pluck(string $value, string|null $key = null): array;
 
     /**
      * Get an array with the values of a given key.
      *
      * @deprecated
+     *
+     * @param  string      $value
+     * @param  string|null $key
+     * @return array
      */
     public function lists(string $value, ?string $key = null): array;
 
     /**
      * Paginate the given query.
+     *
+     * @param  int      $perPage
+     * @param  array    $columns
+     * @param  string   $pageName
+     * @param  int|null $page
+     * @return LengthAwarePaginator
      */
     public function paginate(int $perPage, array $columns = ['*'], string $pageName = 'page', int|null $page = null): LengthAwarePaginator;
 
     /**
      * Find a model in the collection by key.
+     *
+     * @param  int|string  $id
+     * @param  array       $columns
+     * @param  string|null $attribute
+     * @return Model|null
      */
     public function find(int|string $id, array $columns = ['*'], ?string $attribute = null): ?Model;
 
     /**
      * Returns first match or throws exception if not found
+     *
+     * @param  int|string $id
+     * @param  array      $columns
+     * @return Model
      *
      * @throws ModelNotFoundException
      */
@@ -89,26 +127,47 @@ interface BaseRepositoryInterface
 
     /**
      * Find record by the attribute and value combination.
+     *
+     * @param  string $attribute
+     * @param  mixed  $value
+     * @param  array  $columns
+     * @return mixed
      */
     public function findBy(string $attribute, mixed $value, array $columns = ['*']): mixed;
 
     /**
      * Find all collection items matched by the attribute and value pair.
+     *
+     * @param  string $attribute
+     * @param  mixed  $value
+     * @param  array  $columns
+     * @return mixed
      */
     public function findAllBy(string $attribute, mixed $value, array $columns = ['*']): mixed;
 
     /**
      * Find a collection of models by the given query conditions.
+     *
+     * @param  array $where
+     * @param  array $columns
+     * @param  bool  $or
+     * @return Collection|null
      */
     public function findWhere(array $where, array $columns = ['*'], bool $or = false): ?Collection;
 
     /**
      * Makes a new model without persisting it
+     *
+     * @param  array $data
+     * @return Model
      */
     public function make(array $data): Model;
 
     /**
      * Creates a model and returns it
+     *
+     * @param  array $data
+     * @return Model|null
      */
     public function create(array $data): ?Model;
 
@@ -120,15 +179,23 @@ interface BaseRepositoryInterface
      * @param  string|null $attribute
      * @return bool  false if could not find model or not succesful in updating
      */
-    public function update(array $data, mixed $id, ?string $attribute = null);
+    public function update(array $data, mixed $id, ?string $attribute = null): bool;
 
     /**
-     * Finds and fills a model by id, without persisting changes
+     * Finds and fills a model by id, without persisting changes?
+     *
+     * @param  array       $data
+     * @param  mixed       $id
+     * @param  string|null $attribute
+     * @return Model|bool|null
      */
     public function fill(array $data, mixed $id, ?string $attribute = null): null|Model|bool;
 
     /**
      * Deletes a model by $id
+     *
+     * @param  string|int $id
+     * @return bool
      */
     public function delete(int|string $id): bool;
 
@@ -138,7 +205,11 @@ interface BaseRepositoryInterface
      *
      * The callback must be query/builder compatible.
      *
-     * @throws \Exception
+     * @param  Closure $callback
+     * @param  array   $columns
+     * @return Collection
+     *
+     * @throws Exception
      */
     public function allCallback(Closure $callback, array $columns = ['*']): Collection;
 
@@ -148,7 +219,11 @@ interface BaseRepositoryInterface
      *
      * The callback must be query/builder compatible.
      *
-     * @throws \Exception
+     * @param  Closure $callback
+     * @param  array   $columns
+     * @return Collection|Model
+     *
+     * @throws Exception
      */
     public function findCallback(Closure $callback, array $columns = ['*']): Collection|Model;
 
@@ -167,23 +242,32 @@ interface BaseRepositoryInterface
     /**
      * Builds the default criteria and replaces the criteria stack to apply with
      * the default collection.
+     *
+     * @return self
      */
     public function restoreDefaultCriteria(): self;
 
     /**
      * Sets criteria to empty collection
+     *
+     * @return self
      */
     public function clearCriteria(): self;
 
     /**
      * Sets or unsets ignoreCriteria flag. If it is set, all criteria (even
      * those set to apply once!) will be ignored.
+     *
+     * @param  bool $ignore =
+     * @return self
      */
     public function ignoreCriteria(bool $ignore = true): self;
 
     /**
      * Returns a cloned set of all currently set criteria (not including
      * those to be applied once).
+     *
+     * @return Collection
      */
     public function getCriteria(): Collection;
 
@@ -192,6 +276,8 @@ interface BaseRepositoryInterface
      *
      * This takes the default/standard Criteria, then overrides
      * them with whatever is found in the onceCriteria list
+     *
+     * @return self
      */
     public function applyCriteria(): self;
 
@@ -211,6 +297,9 @@ interface BaseRepositoryInterface
 
     /**
      * Removes criteria by key, if it exists
+     *
+     * @param  string $key
+     * @return self
      */
     public function removeCriteria(string $key): self;
 
@@ -218,6 +307,10 @@ interface BaseRepositoryInterface
      * Pushes Criteria, but only for the next call, resets to default afterwards
      * Note that this does NOT work for specific criteria exclusively, it resets
      * to default for ALL Criteria.
+     *
+     * @param  CriteriaInterface    $criteria
+     * @param  string|null          $key
+     * @return self
      */
     public function pushCriteriaOnce(CriteriaInterface $criteria, ?string $key = null): self;
 
@@ -228,6 +321,9 @@ interface BaseRepositoryInterface
      *
      * In effect, this adds a NullCriteria to onceCriteria by key, disabling any criteria
      * by that key in the normal criteria list.
+     *
+     * @param  string $key
+     * @return self
      */
     public function removeCriteriaOnce(string $key): self;
 }

--- a/src/Contracts/BaseRepositoryInterface.php
+++ b/src/Contracts/BaseRepositoryInterface.php
@@ -5,6 +5,7 @@ namespace Czim\Repository\Contracts;
 use Closure;
 use Czim\Repository\Exceptions\RepositoryException;
 use Exception;
+use Illuminate\Contracts\Container\BindingResolutionException;
 use Illuminate\Contracts\Pagination\LengthAwarePaginator;
 use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
 use Illuminate\Database\Eloquent\Collection as EloquentCollection;
@@ -30,6 +31,7 @@ interface BaseRepositoryInterface
      * @return EloquentBuilder|Model
      *
      * @throws RepositoryException
+     * @throws BindingResolutionException
      */
     public function makeModel(bool $storeModel = true): EloquentBuilder | Model;
 
@@ -37,6 +39,9 @@ interface BaseRepositoryInterface
      * Give un executed query for current criteria
      *
      * @return EloquentBuilder
+     *
+     * @throws RepositoryException
+     * @throws BindingResolutionException
      */
     public function query(): EloquentBuilder;
 
@@ -44,6 +49,9 @@ interface BaseRepositoryInterface
      * Does a simple count(*) for the model/scope
      *
      * @return int
+     *
+     * @throws RepositoryException
+     * @throws BindingResolutionException
      */
     public function count(): int;
 
@@ -52,6 +60,9 @@ interface BaseRepositoryInterface
      *
      * @param  array $columns The colums u want to select from your query output
      * @return Model|null
+     *
+     * @throws RepositoryException
+     * @throws BindingResolutionException
      */
     public function first(array $columns = ['*']): ?Model;
 
@@ -62,6 +73,8 @@ interface BaseRepositoryInterface
      * @return Model
      *
      * @throws ModelNotFoundException
+     * @throws RepositoryException
+     * @throws BindingResolutionException
      */
     public function firstOrFail(array $columns = ['*']): Model;
 
@@ -70,6 +83,9 @@ interface BaseRepositoryInterface
      *
      * @param  array $columns
      * @return EloquentCollection
+     *
+     * @throws RepositoryException
+     * @throws BindingResolutionException
      */
     public function all(array $columns = ['*']): EloquentCollection;
 
@@ -79,6 +95,9 @@ interface BaseRepositoryInterface
      * @param  string      $value
      * @param  string|null $key
      * @return array
+     *
+     * @throws RepositoryException
+     * @throws BindingResolutionException
      */
     public function pluck(string $value, string|null $key = null): array;
 
@@ -90,6 +109,9 @@ interface BaseRepositoryInterface
      * @param  string      $value
      * @param  string|null $key
      * @return array
+     *
+     * @throws BindingResolutionException
+     * @throws RepositoryException
      */
     public function lists(string $value, ?string $key = null): array;
 
@@ -101,6 +123,9 @@ interface BaseRepositoryInterface
      * @param  string   $pageName
      * @param  int|null $page
      * @return LengthAwarePaginator
+     *
+     * @throws RepositoryException
+     * @throws BindingResolutionException
      */
     public function paginate(int $perPage, array $columns = ['*'], string $pageName = 'page', int|null $page = null): LengthAwarePaginator;
 
@@ -111,6 +136,9 @@ interface BaseRepositoryInterface
      * @param  array       $columns
      * @param  string|null $attribute
      * @return Model|null
+     *
+     * @throws RepositoryException
+     * @throws BindingResolutionException
      */
     public function find(int|string $id, array $columns = ['*'], ?string $attribute = null): ?Model;
 
@@ -122,6 +150,8 @@ interface BaseRepositoryInterface
      * @return Model
      *
      * @throws ModelNotFoundException
+     * @throws RepositoryException
+     * @throws BindingResolutionException
      */
     public function findOrFail(int|string $id, array $columns = ['*']): Model;
 
@@ -132,8 +162,11 @@ interface BaseRepositoryInterface
      * @param  mixed  $value
      * @param  array  $columns
      * @return mixed
+     *
+     * @throws RepositoryException
+     * @throws BindingResolutionException
      */
-    public function findBy(string $attribute, mixed $value, array $columns = ['*']): mixed;
+    public function findBy(string $attribute, mixed $value, array $columns = ['*']): EloquentBuilder|Model|null;
 
     /**
      * Find all collection items matched by the attribute and value pair.
@@ -142,6 +175,9 @@ interface BaseRepositoryInterface
      * @param  mixed  $value
      * @param  array  $columns
      * @return mixed
+     *
+     * @throws RepositoryException
+     * @throws BindingResolutionException
      */
     public function findAllBy(string $attribute, mixed $value, array $columns = ['*']): mixed;
 
@@ -152,6 +188,9 @@ interface BaseRepositoryInterface
      * @param  array $columns
      * @param  bool  $or
      * @return Collection|null
+     *
+     * @throws RepositoryException
+     * @throws BindingResolutionException
      */
     public function findWhere(array $where, array $columns = ['*'], bool $or = false): ?Collection;
 
@@ -174,10 +213,13 @@ interface BaseRepositoryInterface
     /**
      * Updates a model by $id
      *
+     * Returns false when the model couldn't updated or is not found
+     * in the database storage.
+     *
      * @param  array       $data
      * @param  mixed       $id
      * @param  string|null $attribute
-     * @return bool  false if could not find model or not succesful in updating
+     * @return bool
      */
     public function update(array $data, mixed $id, ?string $attribute = null): bool;
 
@@ -188,6 +230,9 @@ interface BaseRepositoryInterface
      * @param  mixed       $id
      * @param  string|null $attribute
      * @return Model|bool|null
+     *
+     * @throws RepositoryException
+     * @throws BindingResolutionException
      */
     public function fill(array $data, mixed $id, ?string $attribute = null): null|Model|bool;
 
@@ -196,6 +241,9 @@ interface BaseRepositoryInterface
      *
      * @param  string|int $id
      * @return bool
+     *
+     * @throws BindingResolutionException
+     * @throws RepositoryException
      */
     public function delete(int|string $id): bool;
 


### PR DESCRIPTION
With this PR we change the documentation strategy for the methods in the repository. 
We stripped all the docblocks from the base repository. And replaced them with `{@inheritdoc}` because the the interface that is implemented on the base repository has already fully documented docblocks. 

And double docblocks with the same information inside in redundant. 